### PR TITLE
Add and pin pytest dependency; add pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,20 @@
+[pytest]
+addopts =
+    # do not capture any output---necessary for interactive breakpoints
+    -s
+
+    # report any tests that are skipped, xfailed, or xpassed
+    -rsxX
+
+    # report local variables with every stack trace
+    -l
+
+    # output verbosity
+    # show individual test names
+    -vv
+
+    # output short traceback
+    --tb=short
+
+testpaths =
+    tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandoc-include==0.3.2
 capanno-utils==0.1.0a1
 future==0.17.1
+pytest==4.3.1


### PR DESCRIPTION
This PR does two things:

(1) Adds pytest dependency to requirements.txt.  Pins to version 4.3.1.  This version is somewhat out-of-date, but it matches the pytest version on the last truwl/capanno master build in Travis ([link](https://travis-ci.org/github/truwl/capanno/jobs/701452493#L295)).

(2) Adds pytest.ini.  By setting `testpaths = tests/`, we can prevent pytest from scanning the entire project directory for tests to execute.  Locally, this speeds up the pytest execution time by 4-8x (~2min -> 15-30sec).